### PR TITLE
Fix reference to AmplifyTotpSetup.

### DIFF
--- a/docs/ui/auth/fragments/web/authenticator.md
+++ b/docs/ui/auth/fragments/web/authenticator.md
@@ -590,10 +590,10 @@ amplify-authenticator {
 
 ```jsx
 <AmplifyAuthenticator>
-  <AmplifyTOTPSetup
+  <AmplifyTotpSetup
     headerText="My Custom TOTP Setup Text"
     slot="totp-setup"
-  ></AmplifyTOTPSetup>
+  ></AmplifyTotpSetup>
 </AmplifyAuthenticator>
 ```
 


### PR DESCRIPTION
Component was incorrectly capitalised in the documentation.